### PR TITLE
Use isinstance check so library can be used for more types

### DIFF
--- a/flatkeys/__init__.py
+++ b/flatkeys/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: UTF-8 -*-
+import collections
 
 __version__ = '0.1.0'
 
@@ -25,7 +26,7 @@ def flatkeys(d, sep="."):
         prefix, d = dicts.pop()
         for k, v in d.items():
             k_s = str(k)
-            if type(v) is dict:
+            if isinstance(v, collections.Mapping):
                 dicts.append(("%s%s%s" % (prefix, k_s, sep), v))
             else:
                 k_ = prefix + k_s if prefix else k


### PR DESCRIPTION
By using `if isinstance(v, collections.Mapping)` you can make this library work not just for dictionaries but also for the common dictionary types in the standard library (such as `collections.OrderedDict`) as well as subclasses made by the user:

```
>>> d = collections.OrderedDict()
>>> type(d) is dict
False
>>> isinstance(d, collections.Mapping)
True
```
